### PR TITLE
Update pages-menu.ts

### DIFF
--- a/src/app/pages/pages-menu.ts
+++ b/src/app/pages/pages-menu.ts
@@ -151,35 +151,35 @@ export const userMenuItems: MenuItem[] = [   {
   icon: 'arrow-downward-outline',
   key : 'my_dids'
 },
-{
-  title: 'Administration',
-  icon: 'settings-2-outline',
-  key : 'administration',
-  children: [
-{
-  title: 'DID Numbers',
-  link: '/pages/did/did',
-  icon: 'smartphone-outline',
-  key : 'did_number'
-},
-{
-  title: 'Provider / Trunks',
-  link: '/pages/provider/provider',
-  icon: 'shuffle-2-outline',
-  key : 'provider'
-},
-{
-  title: 'User Management',
-  link: '/pages/user/user',
-  icon: 'person-done-outline',
-  key : 'user_management'
-},
-{
-  title: 'Extensions',
-  link: '/pages/extension/extension',
-  icon: 'hash-outline',
-  key : 'extensions'
-},
-],
-},
+//{
+//  title: 'Administration',
+//  icon: 'settings-2-outline',
+//  key : 'administration',
+//  children: [
+//{
+//  title: 'DID Numbers',
+//  link: '/pages/did/did',
+//  icon: 'smartphone-outline',
+//  key : 'did_number'
+//},
+//{
+//  title: 'Provider / Trunks',
+//  link: '/pages/provider/provider',
+//  icon: 'shuffle-2-outline',
+//  key : 'provider'
+//},
+//{
+// title: 'User Management',
+//  link: '/pages/user/user',
+//  icon: 'person-done-outline',
+//  key : 'user_management'
+//},
+//{
+//  title: 'Extensions',
+//  link: '/pages/extension/extension',
+//  icon: 'hash-outline',
+//  key : 'extensions'
+//},
+//],
+//},
 ];

--- a/src/app/pages/pages-menu.ts
+++ b/src/app/pages/pages-menu.ts
@@ -128,7 +128,7 @@ export const userMenuItems: MenuItem[] = [   {
       title: 'Contacts',
       link: '/pages/contact/contacts',
       icon: 'person-add-outline',
-      key : 'contact'
+      key : 'contacts'
     },
     
     // {
@@ -143,7 +143,7 @@ export const userMenuItems: MenuItem[] = [   {
   title: 'Fax Documents',
   link: '/pages/message/document',
   icon: 'file-text-outline',
-  key : 'fax_document'
+  key : 'fax_documents'
 },
 {
   title: 'My DIDs',


### PR DESCRIPTION
remove administration menu for simple users
need in database this permission for user (74 is the user list access):

insert into role_permission (role_id, permission_id) values ('1','74');

Normally this permission should not be granted but if not, the user is login correctly but the dashboard page redirect to sigin if not.