### PR TITLE
Ship a working image: bump ICTCORE_REF + fix php-jwt v7 decode in User.php

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,7 +21,7 @@ FROM rockylinux:8
 # so the build cache invalidates when ICTCore moves. A branch ref caches on the
 # clone command string, which never changes, and silently keeps serving an old
 # checkout. Override with --build-arg to build against a different revision.
-ARG ICTCORE_REF=cb987b5e465f1bc9e1c832722eb8115cff385e16
+ARG ICTCORE_REF=d8274205deff1e5875368350bba67ff44fb439af
 # Remi rather than the AppStream php module, because Rocky 8 tops out at 8.0 and
 # ICTCore needs 8.1 or newer once the patch below is applied.
 ARG PHP_STREAM=remi-8.3

--- a/docker/ictcore-php83.patch
+++ b/docker/ictcore-php83.patch
@@ -528,3 +528,24 @@ index bee82d9..ed4771c 100644
  }
  
  $request = end($argv);
+diff --git a/core/User.php b/core/User.php
+index 22ab67f..490b950 100644
+--- a/core/User.php
++++ b/core/User.php
+@@ -11,6 +11,7 @@ namespace ICT\Core;
+ 
+ use Exception;
+ use Firebase\JWT\JWT;
++use Firebase\JWT\Key;
+ use ICT\Core\User\Permission;
+ use ICT\Core\User\Role;
+ 
+@@ -470,7 +471,7 @@ class User
+           $key_file = Conf::get('security:public_key', '/usr/ictcore/etc/ssh/ib_node.pub');
+           $hash_type = Conf::get('security:hash_type', 'RS256');
+           $public_key = file_get_contents($key_file);
+-          $token = JWT::decode($access_key, $public_key, array($hash_type));
++          $token = JWT::decode($access_key, new Key($public_key, $hash_type));
+           if ($token) {
+             // TODO check api-version
+             if (!empty($token->user_id)) {


### PR DESCRIPTION
Makes a plain `docker build` produce a functioning ICTFax image, closing the gap where the published image was fixed but the source still built a broken one.

**1. Bump `ICTCORE_REF`** to the merged ictcore commit (ictinnovations/ictcore#24) that generates the internal node key at 2048-bit and no longer ships a shared private key. The old pin generated a 1024-bit key that can't sign an RS256 JWT, so `authenticate` failed outright (see #125).

**2. Fix php-jwt v7 decode in `core/User.php`.** The php83 patch upgrades firebase/php-jwt to v7 and already fixed decode in `core/lib/Token.php`, but missed `core/User.php` — the bearer-auth path. With the old signature, every authenticated request threw `Argument #3 ($headers) could not be passed by reference` and 500'd. Adds the same `new Key(...)` fix (one hunk appended to the patch).

Verified end-to-end on a rebuilt image: authenticate, document upload (PDF→TIFF), sendfax program, contact, transmission and status all work. The published `ictinnovations/ictfax:latest` already carries this; this makes the source match.
